### PR TITLE
Update for Crystal 1.0 support and backwards compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
   - Russell Smith <russ@bashme.org>
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: 0.35.1
+crystal: ">= 0.35.1"
 
 license: MIT
 

--- a/spec/bugsnag_spec.cr
+++ b/spec/bugsnag_spec.cr
@@ -25,6 +25,7 @@ describe Bugsnag do
 
   describe "release stages" do
     it "sends when release stage evaluates to true" do
+      # ameba:disable Style/VerboseBlock
       Bugsnag.config { |c| c.release_stage = true }
 
       context = HTTP::Server::Context.new(
@@ -36,6 +37,7 @@ describe Bugsnag do
     end
 
     it "does not send when the release stage does not match" do
+      # ameba:disable Style/VerboseBlock
       Bugsnag.config { |c| c.release_stage = false }
 
       context = HTTP::Server::Context.new(

--- a/src/bugsnag/request.cr
+++ b/src/bugsnag/request.cr
@@ -24,11 +24,17 @@ module Bugsnag
     end
 
     private def set_url(request)
-      url = "#{request.host}#{request.path}"
-      unless request.query_params.empty?
-        url += "?" + filtered_query_params(request.query_params).to_s
+      String.build do |url|
+      {% if compare_versions(Crystal::VERSION, "0.36.0") > 0 %}
+        url << "#{request.hostname}#{request.path}"
+      {% else %}
+        url << "#{request.host}#{request.path}"
+      {% end %}
+        unless request.query_params.empty?
+          url << "?"
+          url << filtered_query_params(request.query_params).to_s
+        end
       end
-      url
     end
 
     private def set_headers(context)


### PR DESCRIPTION
Testing against Crystal 0.35.1, 0.36.1, and 1.0.0

```
❯ crystal spec
....

Finished in 24.92 milliseconds
4 examples, 0 failures, 0 errors, 0 pending

bugsnag on  crystal1.0 [!] via 🔮 v1.0.0 took 4s
❯ ~/Development/crystal/0.35.1/bin/crystal spec
....

Finished in 3.05 milliseconds
4 examples, 0 failures, 0 errors, 0 pending
bugsnag on  crystal1.0 [!] via 🔮 v1.0.0 took 4s
❯ ~/Development/crystal/0.36.1/bin/crystal spec
....

Finished in 23.6 milliseconds
4 examples, 0 failures, 0 errors, 0 pending
```